### PR TITLE
Fix GCC6 Build / File_FindPossibleExtFileName Return

### DIFF
--- a/libretro/gui/file.cpp
+++ b/libretro/gui/file.cpp
@@ -396,7 +396,7 @@ char * File_FindPossibleExtFileName(const char *pszFileName, const char * const 
 	if (!szSrcDir)
 	{
 		perror("File_FindPossibleExtFileName");
-		return false;
+		return NULL;
 	}
 	szSrcName = szSrcDir + FILENAME_MAX;
 	szSrcExt = szSrcName + FILENAME_MAX;


### PR DESCRIPTION
False isn't a valid return type here, GCC6 catches this and fails.
